### PR TITLE
fix unit_divisor error message

### DIFF
--- a/pyega3/pyega3.py
+++ b/pyega3/pyega3.py
@@ -271,7 +271,7 @@ def download_file( token, file_id, file_size, check_sum, num_connections, key, o
 
     chunk_len = math.ceil(file_size/num_connections)
 
-    with tqdm(total=int(file_size), unit='B', unit_scale=True, unit_divisor=1024) as pbar:
+    with tqdm(total=int(file_size), unit='B', unit_scale=True) as pbar:
         params = [(url, token, output_file, chunk_start_pos, min(chunk_len,file_size-chunk_start_pos), pbar) for chunk_start_pos in range(0,file_size, chunk_len)]        
 
         results = []


### PR DESCRIPTION
I am submitting a small change because of the following error. Removing the argument `unit_divisor=1024` allowed me to download this file successfully. I don't know if `tqdm` has been updated or what the source of the error is, but this is no longer a recognized argument.

>  pyega3 -cf CREDENTIALS_FILE fetch EGAF00000850933 EGAF00000850933.saved
> EGA python client version 3.0.21
> 
> Authentication success for user
> File Id: 'EGAF00000850933'(46423419 bytes).
> Download starting [using 1 connection(s)]...
> Unknown argument(s): {'unit_divisor': 1024}
> retry attempt 1
> File Id: 'EGAF00000850933'(46423419 bytes).
> Download starting [using 1 connection(s)]...
> Unknown argument(s): {'unit_divisor': 1024}
> retry attempt 2
> File Id: 'EGAF00000850933'(46423419 bytes).
> Download starting [using 1 connection(s)]...
> Unknown argument(s): {'unit_divisor': 1024}
> retry attempt 3
> File Id: 'EGAF00000850933'(46423419 bytes).
> Download starting [using 1 connection(s)]...
> Unknown argument(s): {'unit_divisor': 1024}
> Traceback (most recent call last):
>   File "/pyega3", line 11, in <module>
>     sys.exit(main())
>   File "/python3.6/site-packages/pyega3/pyega3.py", line 365, in main
>     download_file_retry( token, args.identifier,  file_name, file_size, check_sum, args.connections, key,
> args.saveto )
>   File "/python3.6/site-packages/pyega3/pyega3.py", line 291, in download_file
> _retry
>     raise e
>   File "/python3.6/site-packages/pyega3/pyega3.py", line 286, in download_file
> _retry
>     download_file( token, file_id, file_name, file_size, check_sum, num_connections, key, output_file)
>   File "/python3.6/site-packages/pyega3/pyega3.py", line 256, in download_file
>     with tqdm(total=int(file_size), unit='B', unit_scale=True, unit_divisor=1024) as pbar:
>   File "/python3.6/site-packages/tqdm-4.7.2-py3.6.egg/tqdm/_tqdm.py", line 427
> , in __init__
> Warning: Unknown argument(s): {'unit_divisor': 1024}