### PR TITLE
Specify the encoding of readme.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.txt") as f:
+with open("README.txt", encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Readme.txt contains unicode on line 67, making the package fail to install 
if the users locale is not utf-8.