### PR TITLE
Modify ega-data-api API to have the following behaviour

### DIFF
--- a/pyega3/pyega3.py
+++ b/pyega3/pyega3.py
@@ -261,6 +261,10 @@ def download_file_slice(url, token, file_name, start_pos, length, pbar=None):
 
     with requests.get(url, headers=headers, stream=True) as r:
         print_debug_info(url, None, "Response headers: {}".format(r.headers))
+        if r.status_code == 204:
+            raise Exception("Legacy archive format not supported, please contact EGA to download this file")
+        if r.status_code == 451:
+            raise Exception("Unavailable For legal reasons")
         r.raise_for_status()
         with open(file_name, 'ba') as file_out:
             for chunk in r.iter_content(CHUNK_SIZE):

--- a/test/test_pyega3.py
+++ b/test/test_pyega3.py
@@ -294,6 +294,10 @@ class Pyega3Test(unittest.TestCase):
 
         def request_callback(request):
             auth_hdr = request.headers['Authorization']
+            if auth_hdr == 'Bearer 204':
+                return (204, {}, json.dumps({"error_description": "invalid file"}))
+            if auth_hdr == 'Bearer 451':
+                return (451, {}, json.dumps({"error_description": "Legacy archive format not supported"}))
             if auth_hdr is None or auth_hdr != 'Bearer ' + good_token:
                 return ( 400, {}, json.dumps({"error_description": "invalid token"}) )
 
@@ -336,6 +340,12 @@ class Pyega3Test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pyega3.download_file_slice(rand_str(), rand_str(), file_name, slice_start, -1)
+
+        with self.assertRaises(Exception):
+            pyega3.download_file_slice(good_url, 204, file_name, slice_start, slice_length)
+
+        with self.assertRaises(Exception):
+            pyega3.download_file_slice(good_url, 451, file_name, slice_start, slice_length)            
 
 
     @mock.patch('os.remove')


### PR DESCRIPTION
1) If the file exists but can't be provided due to incompatible format (not AES)
Return Http code 204 with a message body that expresses the reason
2) If the file exists in our databases but it has been removed or, hidden
Return Http code 451 (Unavailable for legal reasons)