### PR TITLE
Fix type str to int because chaneg son python version

### DIFF
--- a/pyega3/libs/data_file.py
+++ b/pyega3/libs/data_file.py
@@ -131,7 +131,7 @@ class DataFile:
                 if file_id != self.id:
                     continue
 
-                if (file_from, file_length) in [(param[1], param[2]) for param in params]:
+                if (int(file_from), int(file_length)) in [(param[1], param[2]) for param in params]:
                     continue
 
                 logging.warning(f'Deleting the leftover {file} temporary file because the MAX_SLICE_SIZE parameter ('


### PR DESCRIPTION
With the latest version on github, the file_from and file_length are str type in file 'libs/data_file.py' and cause comparison fails in Python 3.7.7. We made the fix and add a test to check it. This fixes #139 