### PR TITLE
Preliminary fix for partial download resume functionality

### DIFF
--- a/pyega3/libs/auth_client.py
+++ b/pyega3/libs/auth_client.py
@@ -34,8 +34,8 @@ class AuthClient:
             try:
                 r = requests.post(self.url, headers=headers, data=data)
                 logging.info('')
-                reply = r.json()
                 r.raise_for_status()
+                reply = r.json()
                 oauth_token = reply['access_token']
                 logging.info(f"Authentication success for user '{self.credentials.username}'")
             except ConnectionError:

--- a/pyega3/libs/data_file.py
+++ b/pyega3/libs/data_file.py
@@ -187,14 +187,14 @@ class DataFile:
 
         self.temporary_files.add(file_name)
 
-        existing_size = os.stat(file_name).st_size if os.path.exists(file_name) else 0
+        existing_size = os.stat(final_file_name).st_size if os.path.exists(final_file_name) else 0
         if existing_size > length:
-            os.remove(file_name)
+            os.remove(final_file_name)
         if pbar:
             pbar.update(existing_size)
 
         if existing_size == length:
-            return file_name
+            return final_file_name
 
         try:
             with self.data_client.get_stream(path,


### PR DESCRIPTION
As noted in issues #146 and #147 (and my own experience over the past month), pyega3 fails repeatedly to download large files due to sporadic latency and backend errors (typically either 500 or 504 HTTP status codes during authentication, and often proximal to a drop-off in transfer rate), producing a slew of errors about "Invalid username, password or secret key" (basically the fall-through case here: https://github.com/EGA-archive/ega-download-client/blob/2a0774cb65d8ad99c0e24fc3a46c998e149e9a1c/pyega3/libs/auth_client.py#L46-L50), and then pyega3 retries, but deletes or overwrites all the slices in the temporary directory, essentially restarting from 0.

The incorrect error message is simply due to the `raise_for_status()` call occurring after attempting to parse the response into JSON, so that's easily fixed by moving it up and catching the HTTP status before attempting to parse.

For the partial download resume fix, exceptions raised during authentication cause interruption of the download after the call to `os.rename()`, so the relevant size check should be against the `*.slice` file (`final_file_name`), not the `*.slice.tmp` file (`file_name`).  I'm a bit less confident in the partial download resume fix, but with these fixes I've been able to download three more FASTQs using 10 retries each.  The progress bar and transfer rate estimates look a bit wonky during retries (it's not an instantaneous jump to resume, it takes up to a minute to get there), but it's definitely not restarting from 0.

Anyways, hopefully that helps more folks with successful downloads, and perhaps also reduce strain on the EGA backend  from repeated downloads from 0!

Let me know if there's any testing on my end that would help!

Best regards,
Patrick Reilly