### PR TITLE
EE-2375 Reuse valid file slices on retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 cython_debug/
 
 .idea/
+
+.tmp_download/

--- a/pyega3/libs/auth_client.py
+++ b/pyega3/libs/auth_client.py
@@ -34,8 +34,8 @@ class AuthClient:
             try:
                 r = requests.post(self.url, headers=headers, data=data)
                 logging.info('')
-                reply = r.json()
                 r.raise_for_status()
+                reply = r.json()
                 oauth_token = reply['access_token']
                 logging.info(f"Authentication success for user '{self.credentials.username}'")
             except ConnectionError:

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -8,24 +8,25 @@ from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
 from urllib3.util import retry
 
 
-def create_session_with_retry(retry_policy=None, pool_max_size=None) -> Session:
+def create_session_with_retry(retry_policy: retry.Retry = None, pool_max_size=None) -> Session:
     retry_policy = retry_policy or retry.Retry(
-        total=50,
-        connect=False,
-        # seems that this has a default value of 10,
-        # setting this to a very high number so that it'll respect the status retry count
-
-        status=10,
-        # status is the no. of retries if response is in status_forcelist
-
         status_forcelist=[429, 500, 503, 504],
+        # status is the no. of retries if response is in status_forcelist
+        status=10,
+        # total has a default value of 10,
+        # need to set total to a number higher than status so it'll respect the status retry count
+        total=20,
+        # do not retry connection errors
+        connect=False,
         read=10,
+        # 0.3, 0.6, 1.2, 2.4, 4.8, 9.6, 19.2, 38.4, 76.8, 120 is the BACKOFF_MAX in Retry
         backoff_factor=0.6
     )
     session = Session()
     POOL_MAX_SIZE = max(DEFAULT_POOLSIZE, pool_max_size or 0)
     adapter = HTTPAdapter(max_retries=retry_policy, pool_maxsize=POOL_MAX_SIZE)
-    session.mount('http://', adapter)
+    # TODO check if this can be removed
+    # session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
 

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -25,8 +25,6 @@ def create_session_with_retry(retry_policy: retry.Retry = None, pool_max_size=No
     session = Session()
     POOL_MAX_SIZE = max(DEFAULT_POOLSIZE, pool_max_size or 0)
     adapter = HTTPAdapter(max_retries=retry_policy, pool_maxsize=POOL_MAX_SIZE)
-    # TODO check if this can be removed
-    # session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
 

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -3,6 +3,29 @@ import json
 import logging
 
 import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import retry
+
+
+def create_session_with_retry(retry_policy=None) -> Session:
+    retry_policy = retry_policy or retry.Retry(
+        total=50,
+        connect=False,
+        # seems that this has a default value of 10,
+        # setting this to a very high number so that it'll respect the status retry count
+
+        status=10,
+        # status is the no. of retries if response is in status_forcelist
+
+        read=10,
+        backoff_factor=0.6
+    )
+    session = Session()
+    adapter = HTTPAdapter(max_retries=retry_policy)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 class DataClient:
@@ -12,6 +35,7 @@ class DataClient:
         self.htsget_url = htsget_url
         self.auth_client = auth_client
         self.standard_headers = standard_headers
+        self.session = create_session_with_retry()
 
     @staticmethod
     def print_debug_info(url, reply_json, *args):
@@ -43,7 +67,7 @@ class DataClient:
             headers.update(extra_headers)
 
         url = f'{self.url}{path}'
-        with requests.get(url, headers=headers, stream=True) as r:
+        with self.session.get(url, headers=headers, stream=True) as r:
             self.print_debug_info(url, None, f"Response headers: {r.headers}")
             r.raise_for_status()
             yield r

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -36,7 +36,7 @@ class DataClient:
         return reply
 
     @contextlib.contextmanager
-    def get_stream(self, path, extra_headers = None):
+    def get_stream(self, path, extra_headers=None):
         headers = {'Authorization': f'Bearer {self.auth_client.token}'}
         headers.update(self.standard_headers)
         if extra_headers is not None:

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -18,6 +18,7 @@ def create_session_with_retry(retry_policy=None) -> Session:
         status=10,
         # status is the no. of retries if response is in status_forcelist
 
+        status_forcelist=[429, 500, 503, 504],
         read=10,
         backoff_factor=0.6
     )

--- a/pyega3/libs/data_file.py
+++ b/pyega3/libs/data_file.py
@@ -187,14 +187,14 @@ class DataFile:
 
         self.temporary_files.add(file_name)
 
-        existing_size = os.stat(file_name).st_size if os.path.exists(file_name) else 0
+        existing_size = os.stat(final_file_name).st_size if os.path.exists(final_file_name) else 0
         if existing_size > length:
-            os.remove(file_name)
+            os.remove(final_file_name)
         if pbar:
             pbar.update(existing_size)
 
         if existing_size == length:
-            return file_name
+            return final_file_name
 
         try:
             with self.data_client.get_stream(path,

--- a/pyega3/pyega3.py
+++ b/pyega3/pyega3.py
@@ -133,7 +133,8 @@ def main():
     auth_client = AuthClient(server_config.url_auth, server_config.client_secret, standard_headers)
     auth_client.credentials = credentials
 
-    data_client = DataClient(server_config.url_api, server_config.url_api_ticket, auth_client, standard_headers)
+    data_client = DataClient(server_config.url_api, server_config.url_api_ticket, auth_client, standard_headers,
+                             connections=args.connections)
 
     execute_subcommand(args, data_client)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/plain",
     packages=find_packages(),
-    version="4.0.0",
+    version="4.0.1",
     author="EGA team",
     author_email="ega-helpdesk@ebi.ac.uk",
     python_requires=">=3.6",

--- a/test/test_download_file.py
+++ b/test/test_download_file.py
@@ -248,3 +248,9 @@ def test_slice_file_is_reused(mock_data_client, mock_data_server, random_binary_
     assert mock_download_slice.call_count == 13
     assert os.path.exists(extra_slice)
     assert "Deleting the leftover" not in caplog.text
+
+
+def teardown_module():
+    filepath = 'output_file.md5'
+    if os.path.exists(filepath):
+        os.remove(filepath)

--- a/test/test_download_file.py
+++ b/test/test_download_file.py
@@ -201,7 +201,8 @@ def test_the_user_does_not_specifies_a_slice_size(mock_data_client):
     assert mock_download_slice.call_count == math.ceil(file.size / DataFile.DEFAULT_SLICE_SIZE)
 
 
-def test_the_user_specifies_a_custom_slice_size_different_to_before(mock_data_client, mock_data_server, random_binary_file, caplog):
+def test_the_user_specifies_a_custom_slice_size_different_to_before(mock_data_client, mock_data_server,
+                                                                    random_binary_file, caplog):
     # Given: a file that the user has permissions to download and a custom slice size and some slices that were already downloaded with different size.
     mock_data_server.file_content["EGAF123456"] = random_binary_file
     file = DataFile(mock_data_client, file_id="EGAF123456", size=12345, unencrypted_checksum="testChecksum")

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -1,5 +1,6 @@
 import random
 from unittest import mock
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import requests
@@ -108,3 +109,53 @@ def test_chunk_fails_to_download(mock_data_server, mock_data_client, random_bina
     file_name_for_slice = file_name + '-from-' + str(slice_start) + '-len-' + str(slice_length) + '.slice'
     assert not os.path.exists(file_name_for_slice)
     assert not os.path.exists(file_name_for_slice + '.tmp')
+
+
+def test_chunk_fails_to_download(mock_data_server, mock_data_client, random_binary_file):
+    # Given: a file that exist in EGA object store and the user has permissions to access to it
+    file_id = "EGAF1234"
+    mock_data_server.file_content[file_id] = random_binary_file
+
+    slice_start = random.randint(0, len(random_binary_file))
+    slice_length = len(random_binary_file) + 10
+
+    # When: the user unsuccessfully downloads a chunk
+    file_name = common.rand_str()
+    file = DataFile(mock_data_client, file_id)
+    try:
+        file.download_file_slice(file_name, slice_start, slice_length)
+    except:
+        # For the purpose of this test the download should fail
+        pass
+
+    # Then: file for the failed chunk is removed
+    file_name_for_slice = file_name + '-from-' + str(slice_start) + '-len-' + str(slice_length) + '.slice'
+    assert not os.path.exists(file_name_for_slice)
+    assert not os.path.exists(file_name_for_slice + '.tmp')
+
+
+def test_return_slice_file_when_existing(mock_data_server, mock_data_client, random_binary_file):
+    # Given: a slice file exist in tmp directory
+    file_id = "EGAF1234"
+    mock_data_server.file_content[file_id] = random_binary_file
+
+    slice_start = random.randint(0, len(random_binary_file))
+    slice_length = random.randint(0, len(random_binary_file) - slice_start)
+
+    file_name = common.rand_str()
+    file_name_for_slice = f'{file_name}-from-{slice_start}-len-{slice_length}.slice'
+
+    file = DataFile(mock_data_client, file_id)
+
+    mock_stat = Mock()
+    mock_stat.st_size = slice_length
+
+    # When: the slice file is downloaded
+    # Then: the existing slice file with same length is reused and data is not re-fetched
+    with patch.object(mock_data_client, 'get_stream', wraps=mock_data_client.get_stream) as get_stream_mock:
+        with mock.patch("os.path.exists", lambda path: True if path == file_name_for_slice else False):
+            with mock.patch("os.path.getsize", lambda path: slice_length):
+                with mock.patch("os.stat", lambda path: mock_stat):
+                    filename = file.download_file_slice(file_name, slice_start, slice_length)
+                    assert filename == file_name_for_slice
+                    get_stream_mock.assert_not_called()

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -35,7 +35,8 @@ def test_download_file_slice_downloads_correct_bytes_to_file(mock_data_server, s
         written_bytes += buf_len
 
     file_name = common.rand_str()
-    file_name_for_slice = file_name + '-from-' + str(slice_file.start) + '-len-' + str(slice_file.length) + '.slice.tmp'
+    file_name_for_slice = file_name + '-from-' + str(slice_file.start) + '-len-' + str(
+        slice_file.length) + '.slice.tmp'
 
     file = DataFile(mock_data_client, slice_file.id)
 
@@ -87,6 +88,7 @@ def test_slice_file_name_removes_tmp_suffix_when_successful(mock_data_server, mo
 
     # Then: the suffix .tmp is removed from file for the successful chunk
     assert os.path.exists(slice_file.file_name)
+    os.remove(slice_file.file_name)
     assert not os.path.exists(slice_file.file_name + '.tmp')
 
 
@@ -147,3 +149,5 @@ def test_remove_existing_slice_file_when_it_exceeds_slice_length(mock_data_serve
         # Then: the existing slice file is deleted
         assert output_file == slice_file.file_name
         remove_file_mock.assert_called_once_with(slice_file.file_name)
+
+    os.remove(slice_file.file_name)

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -8,6 +8,8 @@ import pytest
 import requests
 import os
 
+from urllib3.exceptions import NewConnectionError
+
 import test.conftest as common
 from pyega3.libs.data_file import DataFile
 
@@ -63,7 +65,7 @@ def test_error_when_bad_token(mock_data_server, mock_data_client):
 
 def test_error_when_bad_url(mock_data_client):
     file = DataFile(mock_data_client, "bad/url")
-    with pytest.raises(requests.exceptions.ConnectionError):
+    with pytest.raises(NewConnectionError):
         file.download_file_slice(common.rand_str(), 1, 10)
 
 

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -135,7 +135,7 @@ def test_chunk_fails_to_download(mock_data_server, mock_data_client, random_bina
 
 
 def test_return_slice_file_when_existing(mock_data_server, mock_data_client, random_binary_file):
-    # Given: a slice file exist in tmp directory
+    # Given: a slice file existing in tmp directory
     file_id = "EGAF1234"
     mock_data_server.file_content[file_id] = random_binary_file
 

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -1,3 +1,4 @@
+import glob
 import random
 from collections import namedtuple
 from unittest import mock
@@ -88,7 +89,6 @@ def test_slice_file_name_removes_tmp_suffix_when_successful(mock_data_server, mo
 
     # Then: the suffix .tmp is removed from file for the successful chunk
     assert os.path.exists(slice_file.file_name)
-    os.remove(slice_file.file_name)
     assert not os.path.exists(slice_file.file_name + '.tmp')
 
 
@@ -150,4 +150,7 @@ def test_remove_existing_slice_file_when_it_exceeds_slice_length(mock_data_serve
         assert output_file == slice_file.file_name
         remove_file_mock.assert_called_once_with(slice_file.file_name)
 
-    os.remove(slice_file.file_name)
+
+def teardown_module():
+    for f in glob.glob(f'{os.getcwd()}/*.slice'):
+        os.remove(f)

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -111,29 +111,6 @@ def test_chunk_fails_to_download(mock_data_server, mock_data_client, random_bina
     assert not os.path.exists(file_name_for_slice + '.tmp')
 
 
-def test_chunk_fails_to_download(mock_data_server, mock_data_client, random_binary_file):
-    # Given: a file that exist in EGA object store and the user has permissions to access to it
-    file_id = "EGAF1234"
-    mock_data_server.file_content[file_id] = random_binary_file
-
-    slice_start = random.randint(0, len(random_binary_file))
-    slice_length = len(random_binary_file) + 10
-
-    # When: the user unsuccessfully downloads a chunk
-    file_name = common.rand_str()
-    file = DataFile(mock_data_client, file_id)
-    try:
-        file.download_file_slice(file_name, slice_start, slice_length)
-    except:
-        # For the purpose of this test the download should fail
-        pass
-
-    # Then: file for the failed chunk is removed
-    file_name_for_slice = file_name + '-from-' + str(slice_start) + '-len-' + str(slice_length) + '.slice'
-    assert not os.path.exists(file_name_for_slice)
-    assert not os.path.exists(file_name_for_slice + '.tmp')
-
-
 def test_return_slice_file_when_existing(mock_data_server, mock_data_client, random_binary_file):
     # Given: a slice file existing in tmp directory
     file_id = "EGAF1234"


### PR DESCRIPTION
Reuse valid (i.e. same length) file slices on retries to avoid re-fetching the data from the download API.
https://www.ebi.ac.uk/panda/jira/browse/EE-2375

Fix from https://github.com/EGA-archive/ega-download-client/pull/148