### PR TITLE
EE-2375 Use retry policy for requests

### DIFF
--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -8,24 +8,25 @@ from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
 from urllib3.util import retry
 
 
-def create_session_with_retry(retry_policy=None, pool_max_size=None) -> Session:
+def create_session_with_retry(retry_policy: retry.Retry = None, pool_max_size=None) -> Session:
     retry_policy = retry_policy or retry.Retry(
-        total=50,
-        connect=False,
-        # seems that this has a default value of 10,
-        # setting this to a very high number so that it'll respect the status retry count
-
-        status=10,
-        # status is the no. of retries if response is in status_forcelist
-
         status_forcelist=[429, 500, 503, 504],
+        # status is the no. of retries if response is in status_forcelist
+        status=10,
+        # total has a default value of 10,
+        # need to set total to a number higher than status so it'll respect the status retry count
+        total=20,
+        # do not retry connection errors
+        connect=False,
         read=10,
+        # 0.3, 0.6, 1.2, 2.4, 4.8, 9.6, 19.2, 38.4, 76.8, 120 is the BACKOFF_MAX in Retry
         backoff_factor=0.6
     )
     session = Session()
     POOL_MAX_SIZE = max(DEFAULT_POOLSIZE, pool_max_size or 0)
     adapter = HTTPAdapter(max_retries=retry_policy, pool_maxsize=POOL_MAX_SIZE)
-    session.mount('http://', adapter)
+    # TODO check if this can be removed
+    # session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
 

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -25,8 +25,6 @@ def create_session_with_retry(retry_policy: retry.Retry = None, pool_max_size=No
     session = Session()
     POOL_MAX_SIZE = max(DEFAULT_POOLSIZE, pool_max_size or 0)
     adapter = HTTPAdapter(max_retries=retry_policy, pool_maxsize=POOL_MAX_SIZE)
-    # TODO check if this can be removed
-    # session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
 

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -3,6 +3,29 @@ import json
 import logging
 
 import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import retry
+
+
+def create_session_with_retry(retry_policy=None) -> Session:
+    retry_policy = retry_policy or retry.Retry(
+        total=50,
+        connect=False,
+        # seems that this has a default value of 10,
+        # setting this to a very high number so that it'll respect the status retry count
+
+        status=10,
+        # status is the no. of retries if response is in status_forcelist
+
+        read=10,
+        backoff_factor=0.6
+    )
+    session = Session()
+    adapter = HTTPAdapter(max_retries=retry_policy)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 class DataClient:
@@ -12,6 +35,7 @@ class DataClient:
         self.htsget_url = htsget_url
         self.auth_client = auth_client
         self.standard_headers = standard_headers
+        self.session = create_session_with_retry()
 
     @staticmethod
     def print_debug_info(url, reply_json, *args):
@@ -43,7 +67,7 @@ class DataClient:
             headers.update(extra_headers)
 
         url = f'{self.url}{path}'
-        with requests.get(url, headers=headers, stream=True) as r:
+        with self.session.get(url, headers=headers, stream=True) as r:
             self.print_debug_info(url, None, f"Response headers: {r.headers}")
             r.raise_for_status()
             yield r

--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -18,6 +18,7 @@ def create_session_with_retry(retry_policy=None) -> Session:
         status=10,
         # status is the no. of retries if response is in status_forcelist
 
+        status_forcelist=[429, 500, 503, 504],
         read=10,
         backoff_factor=0.6
     )

--- a/pyega3/pyega3.py
+++ b/pyega3/pyega3.py
@@ -133,7 +133,8 @@ def main():
     auth_client = AuthClient(server_config.url_auth, server_config.client_secret, standard_headers)
     auth_client.credentials = credentials
 
-    data_client = DataClient(server_config.url_api, server_config.url_api_ticket, auth_client, standard_headers)
+    data_client = DataClient(server_config.url_api, server_config.url_api_ticket, auth_client, standard_headers,
+                             connections=args.connections)
 
     execute_subcommand(args, data_client)
 

--- a/test/test_download_file_slice.py
+++ b/test/test_download_file_slice.py
@@ -8,6 +8,8 @@ import pytest
 import requests
 import os
 
+from urllib3.exceptions import NewConnectionError
+
 import test.conftest as common
 from pyega3.libs.data_file import DataFile
 
@@ -63,7 +65,7 @@ def test_error_when_bad_token(mock_data_server, mock_data_client):
 
 def test_error_when_bad_url(mock_data_client):
     file = DataFile(mock_data_client, "bad/url")
-    with pytest.raises(requests.exceptions.ConnectionError):
+    with pytest.raises(NewConnectionError):
         file.download_file_slice(common.rand_str(), 1, 10)
 
 


### PR DESCRIPTION
Use retry policy for requests. The overall retry (for any errors in download_file) has 60s default every retry. This is too long. The retry policy should have a back off timeout for every retry so this shouldn't hammer the download API.
https://www.ebi.ac.uk/panda/jira/browse/EE-2375 