### PR TITLE
EE-2375 Fix version log deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,4 +61,5 @@ deploy:
   script:
     - python setup.py sdist
     - pip install -r requirements.txt
+    - pip install twine
     - twine upload --username __token__ --password $PYPI_SECRET dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,8 +58,7 @@ deploy:
   stage: deploy
   only:
     - tags
-    - master
   script:
     - python setup.py sdist
-    - pip install twine
+    - pip install -r requirements.txt
     - twine upload --username __token__ --password $PYPI_SECRET dist/*


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EE-2375

Changes:

1. The deploy job will install all dependencies as a quick fix for the [deploy job](https://gitlab.ebi.ac.uk/EGA/ega-download-client/-/pipelines/275826) .
I think the ideal solution would be to create a config file/ python module, to source the version both in setup.py and pyega3.py, I'll do this in a separate ticket when we improve the pipeline for this project.

2. Only deploy when a tag is created.