### PR TITLE
EE-2426 Retry GET json to retry GET file metadata HTTP 500 error

### DIFF
--- a/pyega3/libs/data_client.py
+++ b/pyega3/libs/data_client.py
@@ -52,7 +52,7 @@ class DataClient:
         headers.update(self.standard_headers)
 
         url = f"{self.url}{path}"
-        r = requests.get(url, headers=headers)
+        r = self.session.get(url, headers=headers)
         r.raise_for_status()
 
         reply = r.json()


### PR DESCRIPTION
Use session with retry when in get_json function. This is a quick fix to GET file metadata HTTP 500 error

This is a frequent error when downloading a file, see ticket  https://www.ebi.ac.uk/panda/jira/browse/EE-2426