### PR TITLE
speed up the file checking process while resuming the download

### DIFF
--- a/pyega3/libs/data_file.py
+++ b/pyega3/libs/data_file.py
@@ -138,6 +138,8 @@ class DataFile:
                  min(chunk_len, file_size - chunk_start_pos), options, pbar)
                 for chunk_start_pos in range(0, file_size, chunk_len)]
 
+            all_slices = set([(param[1], param[2]) for param in params])
+
             for file in os.listdir(temporary_directory):
                 match = re.match(r"(.*)-from-(\d*)-len-(\d*).*", file)
                 file_id = match.group(1)
@@ -147,7 +149,7 @@ class DataFile:
                 if file_id != self.id:
                     continue
 
-                if (int(file_from), int(file_length)) in [(param[1], param[2]) for param in params]:
+                if (int(file_from), int(file_length)) in all_slices:
                     continue
 
                 logging.warning(f'Deleting the leftover {file} temporary file because the MAX_SLICE_SIZE parameter ('


### PR DESCRIPTION
In Line 150, the list `[(param[1], param[2]) for param in params]` should be generated outside of the for loop,
it slows down the resumption of the download process.

https://github.com/EGA-archive/ega-download-client/blob/f64797be72ba1220361a8154748592bf7b9df124/pyega3/libs/data_file.py#L135-L156

