### PR TITLE
upgrade psutil requirement to 5.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage==4.5.1
-psutil==5.6.6
+psutil==5.6.7
 requests==2.26.0
 responses~=0.16.0
 tqdm==4.19.6


### PR DESCRIPTION
Psutil 5.6.6 cannot be built from source due to a bug on the C source code (https://github.com/giampaolo/psutil/issues/1630).
The issue was fixed in 5.6.7

The current version is 5.9.5 but I don't know if pyega3 is will work with newer versions