### PR TITLE
EE-2785 Fix package job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,8 @@ build_package:
     stage: build
     only:
         - tags
-        - EE-2785_fix-package-job
+    except:
+        - branches
     script:
         - pip install -r requirements.txt
         - python setup.py sdist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # This file is a template, and might need editing before it works on your project.
 # Official language image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/python/tags/
-image: python:3.11.6-alpine
+image: python:3.11.6
 stages:
     - test
     - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,8 +59,6 @@ build_package:
     only:
         - tags
         - EE-2785_fix-package-job
-    except:
-        - branches
     script:
         - pip install -r requirements.txt
         - python setup.py sdist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # This file is a template, and might need editing before it works on your project.
 # Official language image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/python/tags/
-image: python:3.11.6-slim
+image: python:3.11.6-alpine
 stages:
     - test
     - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # This file is a template, and might need editing before it works on your project.
 # Official language image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/python/tags/
-image: python:latest
+image: python:3.11.6-slim
 stages:
     - test
     - build
@@ -58,6 +58,7 @@ build_package:
     stage: build
     only:
         - tags
+        - EE-2785_fix-package-job
     except:
         - branches
     script:


### PR DESCRIPTION
There's a failure in using the Python docker image 3.12.0 when building the package: https://gitlab.ebi.ac.uk/EGA/ega-download-client/-/jobs/1445171

Pinning the version to 3.11.6 for now. Tested the docker image version for the build_package job in the GitLab pipeline it was successful: https://gitlab.ebi.ac.uk/EGA/ega-download-client/-/pipelines/456618